### PR TITLE
Add database schema and seed data

### DIFF
--- a/sql/sample_data.sql
+++ b/sql/sample_data.sql
@@ -1,0 +1,33 @@
+-- Sample data for Employee Task Management System
+
+-- Sample Users
+INSERT INTO users (name, email, password, role) VALUES
+('Alice Johnson', 'alice@example.com', '$2y$12$K2FJAg6JUhLuQfdJkNEwrO2Jw6YbxOfeLyzjH326WYISLhGB/TfAq', 'user'),
+('Bob Smith', 'bob@example.com', '$2y$12$K2FJAg6JUhLuQfdJkNEwrO2Jw6YbxOfeLyzjH326WYISLhGB/TfAq', 'user'),
+('Charlie Brown', 'charlie@example.com', '$2y$12$K2FJAg6JUhLuQfdJkNEwrO2Jw6YbxOfeLyzjH326WYISLhGB/TfAq', 'user'),
+('Diana Prince', 'diana@example.com', '$2y$12$K2FJAg6JUhLuQfdJkNEwrO2Jw6YbxOfeLyzjH326WYISLhGB/TfAq', 'user'),
+('Eve Adams', 'eve@example.com', '$2y$12$K2FJAg6JUhLuQfdJkNEwrO2Jw6YbxOfeLyzjH326WYISLhGB/TfAq', 'user');
+
+-- Sample Tasks
+INSERT INTO tasks (title, description, status, creator_id, assignee_id) VALUES
+('Prepare project proposal', 'Gather requirements and prepare proposal', 'pending', 1, 2),
+('Develop login module', 'Implement authentication', 'in_progress', 1, 3),
+('Create database schema', 'Design initial database tables', 'completed', 1, 2),
+('Set up CI/CD pipeline', 'Configure continuous integration and deployment', 'on_hold', 1, 4),
+('Design landing page', 'Create responsive landing page', 'pending', 1, 5),
+('Write unit tests', 'Add tests for core features', 'in_progress', 1, 6),
+('Fix bug #123', 'Resolve reported issue in production', 'completed', 1, 2),
+('Update documentation', 'Refresh project documentation', 'pending', 1, 3),
+('Optimize database queries', 'Improve query performance', 'in_progress', 1, 4),
+('Refactor codebase', 'Clean up legacy code', 'on_hold', 1, 5),
+('Prepare release notes', 'Summarize changes for release', 'completed', 1, 6),
+('Conduct user training', 'Hold training session for users', 'pending', 1, 2),
+('Implement caching', 'Add caching layer for faster responses', 'in_progress', 1, 3),
+('Review pull requests', 'Review incoming PRs', 'completed', 1, 4),
+('Set up monitoring', 'Establish system monitoring', 'pending', 1, 5),
+('Update API endpoints', 'Modify endpoints for new requirements', 'in_progress', 1, 6),
+('Migrate legacy data', 'Move old data to new system', 'cancelled', 1, 2),
+('Research new tools', 'Investigate tools for productivity', 'completed', 1, 3),
+('Plan sprint backlog', 'Organize tasks for next sprint', 'pending', 1, 4),
+('Security audit', 'Perform security assessment', 'cancelled', 1, 5);
+

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,87 @@
+-- Schema for Employee Task Management System
+
+CREATE TABLE users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  email VARCHAR(150) NOT NULL,
+  password VARCHAR(255) NOT NULL,
+  role ENUM('admin','user') DEFAULT 'user',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY idx_users_email (email)
+);
+
+CREATE TABLE tasks (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  title VARCHAR(255) NOT NULL,
+  description TEXT,
+  status ENUM('pending','in_progress','completed','on_hold','cancelled') DEFAULT 'pending',
+  creator_id INT NOT NULL,
+  assignee_id INT DEFAULT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (creator_id) REFERENCES users(id),
+  FOREIGN KEY (assignee_id) REFERENCES users(id),
+  INDEX idx_tasks_status (status),
+  INDEX idx_tasks_assignee (assignee_id),
+  INDEX idx_tasks_created_at (created_at)
+);
+
+CREATE TABLE comments (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  task_id INT NOT NULL,
+  user_id INT NOT NULL,
+  content TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  INDEX idx_comments_task_id (task_id)
+);
+
+CREATE TABLE attachments (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  task_id INT NOT NULL,
+  file_path VARCHAR(255) NOT NULL,
+  uploaded_by INT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+  FOREIGN KEY (uploaded_by) REFERENCES users(id),
+  INDEX idx_attachments_task_id (task_id)
+);
+
+CREATE TABLE activities (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  task_id INT,
+  action VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id),
+  FOREIGN KEY (task_id) REFERENCES tasks(id),
+  INDEX idx_activities_user_id (user_id)
+);
+
+CREATE TABLE notifications (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  message VARCHAR(255) NOT NULL,
+  is_read TINYINT(1) DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id),
+  INDEX idx_notifications_user_id (user_id),
+  INDEX idx_notifications_is_read (is_read)
+);
+
+CREATE TABLE password_resets (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  token VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  expires_at TIMESTAMP NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id),
+  UNIQUE KEY idx_password_resets_token (token),
+  INDEX idx_password_resets_user_id (user_id)
+);
+
+-- Insert default admin user
+INSERT INTO users (name, email, password, role) VALUES
+('Administrator', 'admin@ttsetglobal.com', '$2y$12$gv2/4ZWOi1r1N67cADScruRvrI/gXZ0FtWFtI1pXcurh6KiyjaMXK', 'admin');
+


### PR DESCRIPTION
## Summary
- define core tables for users, tasks, comments, attachments, activities, notifications, and password resets
- add indexes for frequent queries and seed default admin user
- provide sample data with additional users and diverse tasks

## Testing
- `php -l config/config.php`
- `php -l config/db.php`


------
https://chatgpt.com/codex/tasks/task_e_68a10ddaf744832d98202bc1e9af1ad0