### PR TITLE
Add middleware and utility helpers

### DIFF
--- a/middleware/admin.php
+++ b/middleware/admin.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Admin authorization middleware.
+ */
+
+declare(strict_types=1);
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+require_once __DIR__ . '/auth.php';
+
+/**
+ * Ensure the current user has admin role.
+ */
+function require_admin(): void
+{
+    require_login();
+
+    if (($_SESSION['user']['role'] ?? '') !== 'admin') {
+        http_response_code(403);
+        exit('Access denied');
+    }
+}

--- a/middleware/auth.php
+++ b/middleware/auth.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Authentication middleware.
+ */
+
+declare(strict_types=1);
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+/**
+ * Ensure the user is logged in, otherwise redirect to login page.
+ */
+function require_login(): void
+{
+    if (empty($_SESSION['user'])) {
+        header('Location: ' . BASE_URL . '/login.php');
+        exit;
+    }
+}

--- a/middleware/csrf.php
+++ b/middleware/csrf.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * CSRF protection helpers.
+ */
+
+declare(strict_types=1);
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+/**
+ * Generate and store a CSRF token in the session.
+ */
+function generate_csrf_token(): string
+{
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+
+    return $_SESSION['csrf_token'];
+}
+
+/**
+ * Verify a provided CSRF token against the session.
+ */
+function verify_csrf_token(string $token): bool
+{
+    return isset($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $token);
+}

--- a/utils/helpers.php
+++ b/utils/helpers.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * General helper functions.
+ */
+
+declare(strict_types=1);
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+/**
+ * Sanitize a string for safe output.
+ */
+function sanitize(string $value): string
+{
+    return htmlspecialchars(trim($value), ENT_QUOTES, 'UTF-8');
+}
+
+/**
+ * Redirect to a given path within the application.
+ */
+function redirect(string $path): void
+{
+    header('Location: ' . BASE_URL . '/' . ltrim($path, '/'));
+    exit;
+}
+
+/**
+ * Flash messaging helper. Stores message when provided, retrieves and clears when not.
+ */
+function flash(string $key, ?string $message = null): ?string
+{
+    if ($message === null) {
+        $msg = $_SESSION['flash'][$key] ?? null;
+        if ($msg !== null) {
+            unset($_SESSION['flash'][$key]);
+        }
+        return $msg;
+    }
+
+    $_SESSION['flash'][$key] = $message;
+    return null;
+}
+
+/**
+ * Determine if the current request is a POST.
+ */
+function is_post(): bool
+{
+    return ($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST';
+}
+
+/**
+ * Retrieve the currently authenticated user, if any.
+ */
+function current_user(): ?array
+{
+    return $_SESSION['user'] ?? null;
+}

--- a/utils/pagination.php
+++ b/utils/pagination.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Pagination utilities.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Calculate pagination data.
+ *
+ * @param int $total       Total number of records.
+ * @param int $perPage     Records per page.
+ * @param int $currentPage Current page number (1-indexed).
+ *
+ * @return array{total:int,per_page:int,current_page:int,total_pages:int,offset:int,limit:int}
+ */
+function paginate(int $total, int $perPage, int $currentPage = 1): array
+{
+    $totalPages = (int)ceil($total / $perPage);
+    $currentPage = max(1, min($currentPage, $totalPages));
+    $offset = ($currentPage - 1) * $perPage;
+
+    return [
+        'total'        => $total,
+        'per_page'     => $perPage,
+        'current_page' => $currentPage,
+        'total_pages'  => $totalPages,
+        'offset'       => $offset,
+        'limit'        => $perPage,
+    ];
+}

--- a/utils/upload.php
+++ b/utils/upload.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * File upload utilities.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Validate and store an uploaded file.
+ *
+ * @param array $file The $_FILES entry.
+ *
+ * @return string|null The relative path of the stored file or null on failure.
+ */
+function handle_upload(array $file): ?string
+{
+    if (($file['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
+        return null;
+    }
+
+    $allowed = ['pdf', 'png', 'jpg', 'jpeg'];
+    $maxSize = 5 * 1024 * 1024; // 5MB
+
+    $ext = strtolower(pathinfo($file['name'], PATHINFO_EXTENSION));
+    if (!in_array($ext, $allowed, true)) {
+        return null;
+    }
+
+    if (($file['size'] ?? 0) > $maxSize) {
+        return null;
+    }
+
+    $uploadDir = __DIR__ . '/../public/uploads';
+    if (!is_dir($uploadDir)) {
+        mkdir($uploadDir, 0777, true);
+    }
+
+    $filename = uniqid('', true) . '.' . $ext;
+    $targetPath = $uploadDir . '/' . $filename;
+    if (!move_uploaded_file($file['tmp_name'], $targetPath)) {
+        return null;
+    }
+
+    return '/public/uploads/' . $filename;
+}


### PR DESCRIPTION
## Summary
- add authentication middleware for session login checks
- add admin authorization and CSRF utilities
- implement helpers, pagination, and secure upload handling

## Testing
- `php -l middleware/auth.php`
- `php -l middleware/admin.php`
- `php -l middleware/csrf.php`
- `php -l utils/helpers.php`
- `php -l utils/pagination.php`
- `php -l utils/upload.php`


------
https://chatgpt.com/codex/tasks/task_e_68a10f3fb920832d9ad2240a5274708d