### PR TITLE
Add authentication controller and views

### DIFF
--- a/auth/login.php
+++ b/auth/login.php
@@ -1,0 +1,39 @@
+<?php
+require_once __DIR__ . '/../controllers/AuthController.php';
+
+AuthController::login();
+$token = generate_csrf_token();
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Login</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container mt-5" style="max-width: 400px;">
+    <h2 class="mb-4">Login</h2>
+    <?php if ($msg = flash('error')): ?>
+        <div class="alert alert-danger"><?= $msg ?></div>
+    <?php elseif ($msg = flash('success')): ?>
+        <div class="alert alert-success"><?= $msg ?></div>
+    <?php endif; ?>
+    <form method="post" action="">
+        <input type="hidden" name="csrf_token" value="<?= $token ?>">
+        <div class="mb-3">
+            <label for="email" class="form-label">Email</label>
+            <input type="email" class="form-control" id="email" name="email" required>
+        </div>
+        <div class="mb-3">
+            <label for="password" class="form-label">Password</label>
+            <input type="password" class="form-control" id="password" name="password" required>
+        </div>
+        <button type="submit" class="btn btn-primary w-100">Login</button>
+    </form>
+    <div class="mt-3">
+        <a href="password_reset_request.php">Forgot password?</a>
+    </div>
+</div>
+</body>
+</html>

--- a/auth/logout.php
+++ b/auth/logout.php
@@ -1,0 +1,4 @@
+<?php
+require_once __DIR__ . '/../controllers/AuthController.php';
+
+AuthController::logout();

--- a/auth/password_reset.php
+++ b/auth/password_reset.php
@@ -1,0 +1,38 @@
+<?php
+require_once __DIR__ . '/../controllers/AuthController.php';
+
+AuthController::resetPassword();
+$csrf = generate_csrf_token();
+$resetToken = sanitize($_GET['token'] ?? ($_POST['token'] ?? ''));
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Set New Password</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container mt-5" style="max-width: 400px;">
+    <h2 class="mb-4">Reset Password</h2>
+    <?php if ($msg = flash('error')): ?>
+        <div class="alert alert-danger"><?= $msg ?></div>
+    <?php elseif ($msg = flash('success')): ?>
+        <div class="alert alert-success"><?= $msg ?></div>
+    <?php endif; ?>
+    <form method="post" action="">
+        <input type="hidden" name="csrf_token" value="<?= $csrf ?>">
+        <input type="hidden" name="token" value="<?= $resetToken ?>">
+        <div class="mb-3">
+            <label for="password" class="form-label">New Password</label>
+            <input type="password" class="form-control" id="password" name="password" required>
+        </div>
+        <div class="mb-3">
+            <label for="confirm_password" class="form-label">Confirm Password</label>
+            <input type="password" class="form-control" id="confirm_password" name="confirm_password" required>
+        </div>
+        <button type="submit" class="btn btn-primary w-100">Reset Password</button>
+    </form>
+</div>
+</body>
+</html>

--- a/auth/password_reset_request.php
+++ b/auth/password_reset_request.php
@@ -1,0 +1,32 @@
+<?php
+require_once __DIR__ . '/../controllers/AuthController.php';
+
+AuthController::requestPasswordReset();
+$token = generate_csrf_token();
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Password Reset</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container mt-5" style="max-width: 400px;">
+    <h2 class="mb-4">Request Password Reset</h2>
+    <?php if ($msg = flash('error')): ?>
+        <div class="alert alert-danger"><?= $msg ?></div>
+    <?php elseif ($msg = flash('success')): ?>
+        <div class="alert alert-success"><?= $msg ?></div>
+    <?php endif; ?>
+    <form method="post" action="">
+        <input type="hidden" name="csrf_token" value="<?= $token ?>">
+        <div class="mb-3">
+            <label for="email" class="form-label">Email</label>
+            <input type="email" class="form-control" id="email" name="email" required>
+        </div>
+        <button type="submit" class="btn btn-primary w-100">Send Reset Link</button>
+    </form>
+</div>
+</body>
+</html>

--- a/controllers/AuthController.php
+++ b/controllers/AuthController.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Authentication controller handling login, logout and password resets.
+ */
+
+declare(strict_types=1);
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../utils/helpers.php';
+require_once __DIR__ . '/../middleware/csrf.php';
+
+class AuthController
+{
+    /**
+     * Handle user login.
+     */
+    public static function login(): void
+    {
+        if (is_post()) {
+            $token = $_POST['csrf_token'] ?? '';
+            if (!verify_csrf_token($token)) {
+                http_response_code(400);
+                flash('error', 'Invalid CSRF token.');
+                return;
+            }
+
+            $email = sanitize($_POST['email'] ?? '');
+            $password = $_POST['password'] ?? '';
+
+            if ($email === '' || $password === '') {
+                flash('error', 'Email and password are required.');
+                return;
+            }
+
+            $pdo = Database::getConnection();
+            $stmt = $pdo->prepare('SELECT id, name, email, password, role FROM users WHERE email = :email');
+            $stmt->execute(['email' => $email]);
+            $user = $stmt->fetch();
+
+            if (!$user || !password_verify($password, $user['password'])) {
+                flash('error', 'Invalid credentials.');
+                return;
+            }
+
+            unset($user['password']);
+            $_SESSION['user'] = $user;
+            flash('success', 'Logged in successfully.');
+            redirect('index.php');
+        } else {
+            generate_csrf_token();
+        }
+    }
+
+    /**
+     * Log out the current user.
+     */
+    public static function logout(): void
+    {
+        $_SESSION = [];
+        if (ini_get('session.use_cookies')) {
+            $params = session_get_cookie_params();
+            setcookie(session_name(), '', time() - 42000, $params['path'], $params['domain'], $params['secure'], $params['httponly']);
+        }
+        session_destroy();
+        flash('success', 'Logged out successfully.');
+        redirect('auth/login.php');
+    }
+
+    /**
+     * Handle password reset request.
+     */
+    public static function requestPasswordReset(): void
+    {
+        if (is_post()) {
+            $token = $_POST['csrf_token'] ?? '';
+            if (!verify_csrf_token($token)) {
+                http_response_code(400);
+                flash('error', 'Invalid CSRF token.');
+                return;
+            }
+
+            $email = sanitize($_POST['email'] ?? '');
+            if ($email === '') {
+                flash('error', 'Email is required.');
+                return;
+            }
+
+            $pdo = Database::getConnection();
+            $stmt = $pdo->prepare('SELECT id FROM users WHERE email = :email');
+            $stmt->execute(['email' => $email]);
+            $user = $stmt->fetch();
+
+            if ($user) {
+                $resetToken = bin2hex(random_bytes(32));
+                $expires = date('Y-m-d H:i:s', time() + 3600);
+                $stmt = $pdo->prepare('INSERT INTO password_resets (user_id, token, expires_at) VALUES (:uid, :token, :expires)');
+                $stmt->execute([
+                    'uid' => $user['id'],
+                    'token' => $resetToken,
+                    'expires' => $expires,
+                ]);
+                // In real app, email would be sent here.
+            }
+
+            flash('success', 'If that email exists, a reset link has been sent.');
+        } else {
+            generate_csrf_token();
+        }
+    }
+
+    /**
+     * Reset password using a valid token.
+     */
+    public static function resetPassword(): void
+    {
+        if (is_post()) {
+            $csrf = $_POST['csrf_token'] ?? '';
+            if (!verify_csrf_token($csrf)) {
+                http_response_code(400);
+                flash('error', 'Invalid CSRF token.');
+                return;
+            }
+
+            $resetToken = sanitize($_POST['token'] ?? '');
+            $password = $_POST['password'] ?? '';
+            $confirm = $_POST['confirm_password'] ?? '';
+
+            if ($password === '' || $confirm === '') {
+                flash('error', 'All fields are required.');
+                return;
+            }
+            if ($password !== $confirm) {
+                flash('error', 'Passwords do not match.');
+                return;
+            }
+
+            $pdo = Database::getConnection();
+            $stmt = $pdo->prepare('SELECT user_id, expires_at FROM password_resets WHERE token = :token');
+            $stmt->execute(['token' => $resetToken]);
+            $row = $stmt->fetch();
+
+            if (!$row || strtotime($row['expires_at']) < time()) {
+                flash('error', 'Invalid or expired reset token.');
+                return;
+            }
+
+            $hash = password_hash($password, PASSWORD_DEFAULT);
+
+            $pdo->beginTransaction();
+            try {
+                $pdo->prepare('UPDATE users SET password = :password WHERE id = :id')
+                    ->execute(['password' => $hash, 'id' => $row['user_id']]);
+                $pdo->prepare('DELETE FROM password_resets WHERE token = :token')
+                    ->execute(['token' => $resetToken]);
+                $pdo->commit();
+                flash('success', 'Password updated. Please log in.');
+                redirect('auth/login.php');
+            } catch (Throwable $e) {
+                $pdo->rollBack();
+                flash('error', 'Could not reset password.');
+            }
+        } else {
+            generate_csrf_token();
+        }
+    }
+}

--- a/middleware/auth.php
+++ b/middleware/auth.php
@@ -15,7 +15,7 @@ if (session_status() === PHP_SESSION_NONE) {
 function require_login(): void
 {
     if (empty($_SESSION['user'])) {
-        header('Location: ' . BASE_URL . '/login.php');
+        header('Location: ' . BASE_URL . '/auth/login.php');
         exit;
     }
 }


### PR DESCRIPTION
## Summary
- add AuthController with login, logout, and password reset flows
- introduce CSRF-protected Bootstrap auth pages
- update auth middleware to point to new login route

## Testing
- `php -l controllers/AuthController.php`
- `php -l auth/login.php`
- `php -l auth/logout.php`
- `php -l auth/password_reset_request.php`
- `php -l auth/password_reset.php`
- `php -l middleware/auth.php`


------
https://chatgpt.com/codex/tasks/task_e_68a11098f090832d9d471f76079ab3cf