### PR TITLE
Add task management with comments, attachments, and notifications

### DIFF
--- a/controllers/CommentController.php
+++ b/controllers/CommentController.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Controller to handle task comments.
+ */
+
+declare(strict_types=1);
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+require_once __DIR__ . '/../models/Comment.php';
+require_once __DIR__ . '/../models/Task.php';
+require_once __DIR__ . '/../models/Activity.php';
+require_once __DIR__ . '/../models/Notification.php';
+require_once __DIR__ . '/../utils/helpers.php';
+require_once __DIR__ . '/../middleware/csrf.php';
+require_once __DIR__ . '/../middleware/auth.php';
+
+class CommentController
+{
+    /**
+     * Store a new comment and notify participants.
+     */
+    public static function store(int $taskId): void
+    {
+        require_login();
+        $token = $_POST['csrf_token'] ?? '';
+        if (!verify_csrf_token($token)) {
+            http_response_code(400);
+            flash('error', 'Invalid CSRF token.');
+            return;
+        }
+        $content = sanitize($_POST['content'] ?? '');
+        if ($content === '') {
+            flash('error', 'Comment cannot be empty.');
+            redirect('views/tasks/view.php?id=' . $taskId);
+        }
+        $user = current_user();
+        Comment::create([
+            'task_id' => $taskId,
+            'user_id' => $user['id'],
+            'content' => $content,
+        ]);
+        Activity::log($user['id'], $taskId, 'commented');
+        $task = Task::find($taskId);
+        if ($task) {
+            $message = 'New comment on task "' . $task['title'] . '"';
+            if (!empty($task['assignee_id']) && (int)$task['assignee_id'] !== $user['id']) {
+                Notification::create((int)$task['assignee_id'], $message);
+            }
+            if ((int)$task['creator_id'] !== $user['id'] && (int)$task['creator_id'] !== (int)$task['assignee_id']) {
+                Notification::create((int)$task['creator_id'], $message);
+            }
+        }
+        flash('success', 'Comment added.');
+        redirect('views/tasks/view.php?id=' . $taskId);
+    }
+}

--- a/controllers/NotificationController.php
+++ b/controllers/NotificationController.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Controller for user notifications.
+ */
+
+declare(strict_types=1);
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+require_once __DIR__ . '/../models/Notification.php';
+require_once __DIR__ . '/../utils/helpers.php';
+require_once __DIR__ . '/../middleware/auth.php';
+require_once __DIR__ . '/../middleware/csrf.php';
+
+class NotificationController
+{
+    /**
+     * List notifications for current user.
+     */
+    public static function index(): array
+    {
+        require_login();
+        $user = current_user();
+        return Notification::forUser($user['id']);
+    }
+
+    /**
+     * Mark a notification as read.
+     */
+    public static function mark(int $id): void
+    {
+        require_login();
+        $token = $_POST['csrf_token'] ?? '';
+        if (!verify_csrf_token($token)) {
+            http_response_code(400);
+            flash('error', 'Invalid CSRF token.');
+            return;
+        }
+        Notification::markAsRead($id);
+        redirect('views/notifications/index.php');
+    }
+}

--- a/controllers/TaskController.php
+++ b/controllers/TaskController.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * Controller handling CRUD operations for tasks.
+ */
+
+declare(strict_types=1);
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+require_once __DIR__ . '/../models/Task.php';
+require_once __DIR__ . '/../models/Comment.php';
+require_once __DIR__ . '/../models/Attachment.php';
+require_once __DIR__ . '/../models/Activity.php';
+require_once __DIR__ . '/../models/Notification.php';
+require_once __DIR__ . '/../utils/helpers.php';
+require_once __DIR__ . '/../utils/pagination.php';
+require_once __DIR__ . '/../utils/upload.php';
+require_once __DIR__ . '/../middleware/csrf.php';
+require_once __DIR__ . '/../middleware/auth.php';
+
+class TaskController
+{
+    /**
+     * Display a listing of tasks with filters and pagination.
+     */
+    public static function index(): array
+    {
+        require_login();
+        $filters = [
+            'status'    => sanitize($_GET['status'] ?? ''),
+            'priority'  => sanitize($_GET['priority'] ?? ''),
+            'assignee'  => isset($_GET['assignee']) ? (int)$_GET['assignee'] : 0,
+            'keyword'   => sanitize($_GET['keyword'] ?? ''),
+            'start_date'=> sanitize($_GET['start_date'] ?? ''),
+            'end_date'  => sanitize($_GET['end_date'] ?? ''),
+        ];
+        $page = isset($_GET['page']) ? max(1, (int)$_GET['page']) : 1;
+        $total = Task::count($filters);
+        $pagination = paginate($total, 10, $page);
+        $tasks = Task::filter($filters, $pagination['limit'], $pagination['offset']);
+        return ['tasks' => $tasks, 'pagination' => $pagination, 'filters' => $filters];
+    }
+
+    /**
+     * Show create form or handle submission.
+     */
+    public static function create(): void
+    {
+        require_login();
+        if (is_post()) {
+            self::store();
+        } else {
+            generate_csrf_token();
+        }
+    }
+
+    /**
+     * Store a newly created task.
+     */
+    public static function store(): void
+    {
+        $token = $_POST['csrf_token'] ?? '';
+        if (!verify_csrf_token($token)) {
+            http_response_code(400);
+            flash('error', 'Invalid CSRF token.');
+            return;
+        }
+        $title = sanitize($_POST['title'] ?? '');
+        $description = sanitize($_POST['description'] ?? '');
+        $status = sanitize($_POST['status'] ?? 'pending');
+        $priority = sanitize($_POST['priority'] ?? 'normal');
+        $assignee = isset($_POST['assignee_id']) ? (int)$_POST['assignee_id'] : null;
+        $user = current_user();
+        if ($title === '') {
+            flash('error', 'Title is required.');
+            return;
+        }
+        $taskId = Task::create([
+            'title'       => $title,
+            'description' => $description,
+            'status'      => $status,
+            'priority'    => $priority,
+            'creator_id'  => $user['id'],
+            'assignee_id' => $assignee,
+        ]);
+        Activity::log($user['id'], $taskId, 'created');
+        if ($assignee !== null) {
+            Activity::log($user['id'], $taskId, 'assigned');
+            Notification::create($assignee, 'You have been assigned to task "' . $title . '"');
+        }
+        flash('success', 'Task created successfully.');
+        redirect('views/tasks/index.php');
+    }
+
+    /**
+     * Show edit form or handle update.
+     */
+    public static function edit(int $id): ?array
+    {
+        require_login();
+        if (is_post()) {
+            self::update($id);
+        } else {
+            generate_csrf_token();
+        }
+        return Task::find($id);
+    }
+
+    /**
+     * Update a task.
+     */
+    public static function update(int $id): void
+    {
+        $token = $_POST['csrf_token'] ?? '';
+        if (!verify_csrf_token($token)) {
+            http_response_code(400);
+            flash('error', 'Invalid CSRF token.');
+            return;
+        }
+        $existing = Task::find($id);
+        if (!$existing) {
+            flash('error', 'Task not found.');
+            return;
+        }
+        $title = sanitize($_POST['title'] ?? '');
+        $description = sanitize($_POST['description'] ?? '');
+        $status = sanitize($_POST['status'] ?? $existing['status']);
+        $priority = sanitize($_POST['priority'] ?? $existing['priority']);
+        $assignee = isset($_POST['assignee_id']) ? (int)$_POST['assignee_id'] : null;
+        if ($title === '') {
+            flash('error', 'Title is required.');
+            return;
+        }
+        Task::update($id, [
+            'title'       => $title,
+            'description' => $description,
+            'status'      => $status,
+            'priority'    => $priority,
+            'assignee_id' => $assignee,
+        ]);
+        $userId = current_user()['id'];
+        Activity::log($userId, $id, 'updated');
+        if ($existing['status'] !== $status) {
+            Activity::log($userId, $id, 'status_changed');
+        }
+        if ((int)($existing['assignee_id'] ?? 0) !== (int)$assignee) {
+            Activity::log($userId, $id, 'assigned');
+            if ($assignee !== null) {
+                Notification::create($assignee, 'You have been assigned to task "' . $title . '"');
+            }
+        }
+        flash('success', 'Task updated successfully.');
+        redirect('views/tasks/index.php');
+    }
+
+    /**
+     * Delete a task.
+     */
+    public static function destroy(int $id): void
+    {
+        require_login();
+        $token = $_POST['csrf_token'] ?? '';
+        if (!verify_csrf_token($token)) {
+            http_response_code(400);
+            flash('error', 'Invalid CSRF token.');
+            return;
+        }
+        Task::delete($id);
+        flash('success', 'Task deleted successfully.');
+        redirect('views/tasks/index.php');
+    }
+
+    /**
+     * Display task details with relations.
+     */
+    public static function view(int $id): array
+    {
+        require_login();
+        $task = Task::find($id);
+        $comments = Comment::forTask($id);
+        $attachments = Attachment::forTask($id);
+        $activities = Activity::forTask($id);
+        generate_csrf_token();
+        return compact('task', 'comments', 'attachments', 'activities');
+    }
+
+    /**
+     * Handle attachment upload for a task.
+     */
+    public static function addAttachment(int $id): void
+    {
+        $token = $_POST['csrf_token'] ?? '';
+        if (!verify_csrf_token($token)) {
+            http_response_code(400);
+            flash('error', 'Invalid CSRF token.');
+            return;
+        }
+        $file = $_FILES['attachment'] ?? null;
+        $path = $file ? handle_upload($file) : null;
+        if ($path === null) {
+            flash('error', 'Invalid file upload.');
+            redirect('views/tasks/view.php?id=' . $id);
+        }
+        $user = current_user();
+        Attachment::create([
+            'task_id'    => $id,
+            'file_path'  => $path,
+            'uploaded_by'=> $user['id'],
+        ]);
+        Activity::log($user['id'], $id, 'attachment_added');
+        flash('success', 'Attachment uploaded.');
+        redirect('views/tasks/view.php?id=' . $id);
+    }
+}

--- a/models/Activity.php
+++ b/models/Activity.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Activity model to log user actions.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../config/db.php';
+
+class Activity
+{
+    /**
+     * Log an activity.
+     */
+    public static function log(int $userId, ?int $taskId, string $action): int
+    {
+        $pdo = Database::getConnection();
+        $stmt = $pdo->prepare('INSERT INTO activities (user_id, task_id, action) VALUES (:user_id, :task_id, :action)');
+        $stmt->execute([
+            'user_id' => $userId,
+            'task_id' => $taskId,
+            'action'  => $action,
+        ]);
+        return (int)$pdo->lastInsertId();
+    }
+
+    /**
+     * Retrieve activity log for a task.
+     */
+    public static function forTask(int $taskId): array
+    {
+        $pdo = Database::getConnection();
+        $sql = 'SELECT a.*, u.name FROM activities a JOIN users u ON a.user_id = u.id WHERE a.task_id = :id ORDER BY a.created_at DESC';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute(['id' => $taskId]);
+        return $stmt->fetchAll();
+    }
+}

--- a/models/Attachment.php
+++ b/models/Attachment.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Attachment model handling file metadata.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../config/db.php';
+
+class Attachment
+{
+    /**
+     * Retrieve attachments for a task.
+     */
+    public static function forTask(int $taskId): array
+    {
+        $pdo = Database::getConnection();
+        $sql = 'SELECT a.*, u.name FROM attachments a JOIN users u ON a.uploaded_by = u.id WHERE a.task_id = :id ORDER BY a.created_at DESC';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute(['id' => $taskId]);
+        return $stmt->fetchAll();
+    }
+
+    /**
+     * Create an attachment record.
+     */
+    public static function create(array $data): int
+    {
+        $pdo = Database::getConnection();
+        $stmt = $pdo->prepare('INSERT INTO attachments (task_id, file_path, uploaded_by) VALUES (:task_id, :file_path, :uploaded_by)');
+        $stmt->execute([
+            'task_id'    => $data['task_id'],
+            'file_path'  => $data['file_path'],
+            'uploaded_by'=> $data['uploaded_by'],
+        ]);
+        return (int)$pdo->lastInsertId();
+    }
+
+    /**
+     * Delete an attachment.
+     */
+    public static function delete(int $id): bool
+    {
+        $pdo = Database::getConnection();
+        $stmt = $pdo->prepare('DELETE FROM attachments WHERE id = :id');
+        return $stmt->execute(['id' => $id]);
+    }
+}

--- a/models/Comment.php
+++ b/models/Comment.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Comment model with CRUD operations.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../config/db.php';
+
+class Comment
+{
+    /**
+     * Retrieve comments for a task.
+     */
+    public static function forTask(int $taskId): array
+    {
+        $pdo = Database::getConnection();
+        $sql = 'SELECT c.*, u.name FROM comments c JOIN users u ON c.user_id = u.id WHERE c.task_id = :id ORDER BY c.created_at ASC';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute(['id' => $taskId]);
+        return $stmt->fetchAll();
+    }
+
+    /**
+     * Create a new comment.
+     */
+    public static function create(array $data): int
+    {
+        $pdo = Database::getConnection();
+        $stmt = $pdo->prepare('INSERT INTO comments (task_id, user_id, content) VALUES (:task_id, :user_id, :content)');
+        $stmt->execute([
+            'task_id' => $data['task_id'],
+            'user_id' => $data['user_id'],
+            'content' => $data['content'],
+        ]);
+        return (int)$pdo->lastInsertId();
+    }
+
+    /**
+     * Delete a comment.
+     */
+    public static function delete(int $id): bool
+    {
+        $pdo = Database::getConnection();
+        $stmt = $pdo->prepare('DELETE FROM comments WHERE id = :id');
+        return $stmt->execute(['id' => $id]);
+    }
+}

--- a/models/Notification.php
+++ b/models/Notification.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Notification model to handle in-app alerts.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../config/db.php';
+
+class Notification
+{
+    /**
+     * Create a notification.
+     */
+    public static function create(int $userId, string $message): int
+    {
+        $pdo = Database::getConnection();
+        $stmt = $pdo->prepare('INSERT INTO notifications (user_id, message) VALUES (:user_id, :message)');
+        $stmt->execute([
+            'user_id' => $userId,
+            'message' => $message,
+        ]);
+        return (int)$pdo->lastInsertId();
+    }
+
+    /**
+     * Retrieve notifications for a user.
+     */
+    public static function forUser(int $userId): array
+    {
+        $pdo = Database::getConnection();
+        $sql = 'SELECT * FROM notifications WHERE user_id = :id ORDER BY created_at DESC';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute(['id' => $userId]);
+        return $stmt->fetchAll();
+    }
+
+    /**
+     * Mark a notification as read.
+     */
+    public static function markAsRead(int $id): bool
+    {
+        $pdo = Database::getConnection();
+        $stmt = $pdo->prepare('UPDATE notifications SET is_read = 1 WHERE id = :id');
+        return $stmt->execute(['id' => $id]);
+    }
+}

--- a/models/Task.php
+++ b/models/Task.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Task model providing CRUD operations and filtering support.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../config/db.php';
+
+class Task
+{
+    /**
+     * Retrieve tasks with optional filters and pagination.
+     *
+     * @param array $filters [status, priority, assignee, keyword, start_date, end_date]
+     * @param int   $limit   Number of records.
+     * @param int   $offset  Offset for pagination.
+     */
+    public static function filter(array $filters = [], int $limit = 10, int $offset = 0): array
+    {
+        $pdo = Database::getConnection();
+        $sql = 'SELECT t.*, u.name AS assignee_name FROM tasks t LEFT JOIN users u ON t.assignee_id = u.id';
+        $conditions = [];
+        $params = [];
+
+        if (!empty($filters['status'])) {
+            $conditions[] = 't.status = :status';
+            $params['status'] = $filters['status'];
+        }
+        if (!empty($filters['priority'])) {
+            $conditions[] = 't.priority = :priority';
+            $params['priority'] = $filters['priority'];
+        }
+        if (!empty($filters['assignee'])) {
+            $conditions[] = 't.assignee_id = :assignee';
+            $params['assignee'] = $filters['assignee'];
+        }
+        if (!empty($filters['keyword'])) {
+            $conditions[] = '(t.title LIKE :kw OR t.description LIKE :kw)';
+            $params['kw'] = '%' . $filters['keyword'] . '%';
+        }
+        if (!empty($filters['start_date'])) {
+            $conditions[] = 't.created_at >= :start_date';
+            $params['start_date'] = $filters['start_date'];
+        }
+        if (!empty($filters['end_date'])) {
+            $conditions[] = 't.created_at <= :end_date';
+            $params['end_date'] = $filters['end_date'];
+        }
+
+        if ($conditions) {
+            $sql .= ' WHERE ' . implode(' AND ', $conditions);
+        }
+        $sql .= ' ORDER BY t.created_at DESC LIMIT :limit OFFSET :offset';
+
+        $stmt = $pdo->prepare($sql);
+        foreach ($params as $key => $value) {
+            $stmt->bindValue(':' . $key, $value);
+        }
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+        $stmt->execute();
+
+        return $stmt->fetchAll();
+    }
+
+    /**
+     * Count tasks matching filters.
+     */
+    public static function count(array $filters = []): int
+    {
+        $pdo = Database::getConnection();
+        $sql = 'SELECT COUNT(*) FROM tasks t';
+        $conditions = [];
+        $params = [];
+
+        if (!empty($filters['status'])) {
+            $conditions[] = 't.status = :status';
+            $params['status'] = $filters['status'];
+        }
+        if (!empty($filters['priority'])) {
+            $conditions[] = 't.priority = :priority';
+            $params['priority'] = $filters['priority'];
+        }
+        if (!empty($filters['assignee'])) {
+            $conditions[] = 't.assignee_id = :assignee';
+            $params['assignee'] = $filters['assignee'];
+        }
+        if (!empty($filters['keyword'])) {
+            $conditions[] = '(t.title LIKE :kw OR t.description LIKE :kw)';
+            $params['kw'] = '%' . $filters['keyword'] . '%';
+        }
+        if (!empty($filters['start_date'])) {
+            $conditions[] = 't.created_at >= :start_date';
+            $params['start_date'] = $filters['start_date'];
+        }
+        if (!empty($filters['end_date'])) {
+            $conditions[] = 't.created_at <= :end_date';
+            $params['end_date'] = $filters['end_date'];
+        }
+
+        if ($conditions) {
+            $sql .= ' WHERE ' . implode(' AND ', $conditions);
+        }
+
+        $stmt = $pdo->prepare($sql);
+        foreach ($params as $key => $value) {
+            $stmt->bindValue(':' . $key, $value);
+        }
+        $stmt->execute();
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Find a task by id.
+     */
+    public static function find(int $id): ?array
+    {
+        $pdo = Database::getConnection();
+        $sql = 'SELECT t.*, u.name AS assignee_name FROM tasks t LEFT JOIN users u ON t.assignee_id = u.id WHERE t.id = :id';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute(['id' => $id]);
+        $task = $stmt->fetch();
+        return $task !== false ? $task : null;
+    }
+
+    /**
+     * Create a new task.
+     */
+    public static function create(array $data): int
+    {
+        $pdo = Database::getConnection();
+        $stmt = $pdo->prepare('INSERT INTO tasks (title, description, status, priority, creator_id, assignee_id) VALUES (:title, :description, :status, :priority, :creator_id, :assignee_id)');
+        $stmt->execute([
+            'title'       => $data['title'],
+            'description' => $data['description'],
+            'status'      => $data['status'],
+            'priority'    => $data['priority'],
+            'creator_id'  => $data['creator_id'],
+            'assignee_id' => $data['assignee_id'],
+        ]);
+        return (int)$pdo->lastInsertId();
+    }
+
+    /**
+     * Update an existing task.
+     */
+    public static function update(int $id, array $data): bool
+    {
+        $pdo = Database::getConnection();
+        $stmt = $pdo->prepare('UPDATE tasks SET title = :title, description = :description, status = :status, priority = :priority, assignee_id = :assignee_id WHERE id = :id');
+        return $stmt->execute([
+            'id'          => $id,
+            'title'       => $data['title'],
+            'description' => $data['description'],
+            'status'      => $data['status'],
+            'priority'    => $data['priority'],
+            'assignee_id' => $data['assignee_id'],
+        ]);
+    }
+
+    /**
+     * Delete a task.
+     */
+    public static function delete(int $id): bool
+    {
+        $pdo = Database::getConnection();
+        $stmt = $pdo->prepare('DELETE FROM tasks WHERE id = :id');
+        return $stmt->execute(['id' => $id]);
+    }
+}

--- a/views/tasks/create.php
+++ b/views/tasks/create.php
@@ -1,0 +1,62 @@
+<?php
+require_once __DIR__ . '/../../controllers/TaskController.php';
+require_once __DIR__ . '/../../models/User.php';
+
+TaskController::create();
+$users = User::all();
+$token = generate_csrf_token();
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Create Task</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container mt-5">
+    <h2 class="mb-4">Create Task</h2>
+    <?php if ($msg = flash('error')): ?>
+        <div class="alert alert-danger"><?= $msg ?></div>
+    <?php endif; ?>
+    <form method="post">
+        <input type="hidden" name="csrf_token" value="<?= $token ?>">
+        <div class="mb-3">
+            <label class="form-label">Title</label>
+            <input type="text" name="title" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Description</label>
+            <textarea name="description" class="form-control" rows="4"></textarea>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Status</label>
+            <select name="status" class="form-select">
+                <?php foreach (['pending','in_progress','completed','on_hold','cancelled'] as $s): ?>
+                    <option value="<?= $s ?>"><?= $s ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Priority</label>
+            <select name="priority" class="form-select">
+                <?php foreach (['low','normal','high'] as $p): ?>
+                    <option value="<?= $p ?>"><?= $p ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Assignee</label>
+            <select name="assignee_id" class="form-select">
+                <option value="">-- Select --</option>
+                <?php foreach ($users as $u): ?>
+                    <option value="<?= $u['id'] ?>"><?= htmlspecialchars($u['name']) ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <button type="submit" class="btn btn-primary">Create</button>
+        <a href="index.php" class="btn btn-secondary">Cancel</a>
+    </form>
+</div>
+</body>
+</html>

--- a/views/tasks/edit.php
+++ b/views/tasks/edit.php
@@ -1,0 +1,63 @@
+<?php
+require_once __DIR__ . '/../../controllers/TaskController.php';
+require_once __DIR__ . '/../../models/User.php';
+
+$id = (int)($_GET['id'] ?? 0);
+$task = TaskController::edit($id);
+$users = User::all();
+$token = generate_csrf_token();
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Edit Task</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container mt-5">
+    <h2 class="mb-4">Edit Task</h2>
+    <?php if ($msg = flash('error')): ?>
+        <div class="alert alert-danger"><?= $msg ?></div>
+    <?php endif; ?>
+    <form method="post">
+        <input type="hidden" name="csrf_token" value="<?= $token ?>">
+        <div class="mb-3">
+            <label class="form-label">Title</label>
+            <input type="text" name="title" class="form-control" value="<?= htmlspecialchars($task['title'] ?? '') ?>" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Description</label>
+            <textarea name="description" class="form-control" rows="4"><?= htmlspecialchars($task['description'] ?? '') ?></textarea>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Status</label>
+            <select name="status" class="form-select">
+                <?php foreach (['pending','in_progress','completed','on_hold','cancelled'] as $s): ?>
+                    <option value="<?= $s ?>"<?= ($task['status'] ?? '') === $s ? ' selected' : '' ?>><?= $s ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Priority</label>
+            <select name="priority" class="form-select">
+                <?php foreach (['low','normal','high'] as $p): ?>
+                    <option value="<?= $p ?>"<?= ($task['priority'] ?? '') === $p ? ' selected' : '' ?>><?= $p ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Assignee</label>
+            <select name="assignee_id" class="form-select">
+                <option value="">-- Select --</option>
+                <?php foreach ($users as $u): ?>
+                    <option value="<?= $u['id'] ?>"<?= (int)($task['assignee_id'] ?? 0) === (int)$u['id'] ? ' selected' : '' ?>><?= htmlspecialchars($u['name']) ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <button type="submit" class="btn btn-primary">Update</button>
+        <a href="index.php" class="btn btn-secondary">Cancel</a>
+    </form>
+</div>
+</body>
+</html>

--- a/views/tasks/index.php
+++ b/views/tasks/index.php
@@ -1,0 +1,115 @@
+<?php
+require_once __DIR__ . '/../../controllers/TaskController.php';
+require_once __DIR__ . '/../../models/User.php';
+
+if (is_post() && isset($_POST['delete_id'])) {
+    TaskController::destroy((int)$_POST['delete_id']);
+}
+
+$data = TaskController::index();
+$tasks = $data['tasks'];
+$pagination = $data['pagination'];
+$filters = $data['filters'];
+$users = User::all();
+$token = generate_csrf_token();
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Tasks</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container mt-5">
+    <h2 class="mb-4">Tasks</h2>
+    <?php if ($msg = flash('success')): ?>
+        <div class="alert alert-success"><?= $msg ?></div>
+    <?php elseif ($msg = flash('error')): ?>
+        <div class="alert alert-danger"><?= $msg ?></div>
+    <?php endif; ?>
+    <a href="create.php" class="btn btn-primary mb-3">Create Task</a>
+    <form method="get" class="row g-2 mb-3">
+        <div class="col">
+            <select name="status" class="form-select">
+                <option value="">Status</option>
+                <?php foreach (['pending','in_progress','completed','on_hold','cancelled'] as $status): ?>
+                    <option value="<?= $status ?>"<?= $filters['status'] === $status ? ' selected' : '' ?>><?= $status ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div class="col">
+            <select name="priority" class="form-select">
+                <option value="">Priority</option>
+                <?php foreach (['low','normal','high'] as $priority): ?>
+                    <option value="<?= $priority ?>"<?= $filters['priority'] === $priority ? ' selected' : '' ?>><?= $priority ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div class="col">
+            <select name="assignee" class="form-select">
+                <option value="">Assignee</option>
+                <?php foreach ($users as $u): ?>
+                    <option value="<?= $u['id'] ?>"<?= (int)$filters['assignee'] === (int)$u['id'] ? ' selected' : '' ?>><?= htmlspecialchars($u['name']) ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div class="col">
+            <input type="date" name="start_date" class="form-control" value="<?= htmlspecialchars($filters['start_date']) ?>" placeholder="Start">
+        </div>
+        <div class="col">
+            <input type="date" name="end_date" class="form-control" value="<?= htmlspecialchars($filters['end_date']) ?>" placeholder="End">
+        </div>
+        <div class="col">
+            <input type="text" name="keyword" class="form-control" value="<?= htmlspecialchars($filters['keyword']) ?>" placeholder="Keyword">
+        </div>
+        <div class="col">
+            <button class="btn btn-secondary" type="submit">Filter</button>
+        </div>
+    </form>
+    <table class="table table-bordered">
+        <thead>
+        <tr>
+            <th>ID</th>
+            <th>Title</th>
+            <th>Status</th>
+            <th>Priority</th>
+            <th>Assignee</th>
+            <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody>
+        <?php foreach ($tasks as $task): ?>
+            <tr>
+                <td><?= $task['id'] ?></td>
+                <td><?= htmlspecialchars($task['title']) ?></td>
+                <td><?= htmlspecialchars($task['status']) ?></td>
+                <td><?= htmlspecialchars($task['priority']) ?></td>
+                <td><?= htmlspecialchars($task['assignee_name'] ?? '') ?></td>
+                <td>
+                    <a href="view.php?id=<?= $task['id'] ?>" class="btn btn-sm btn-info">View</a>
+                    <a href="edit.php?id=<?= $task['id'] ?>" class="btn btn-sm btn-warning">Edit</a>
+                    <form method="post" action="" style="display:inline-block">
+                        <input type="hidden" name="csrf_token" value="<?= $token ?>">
+                        <input type="hidden" name="delete_id" value="<?= $task['id'] ?>">
+                        <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Delete this task?')">Delete</button>
+                    </form>
+                </td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+    <?php if ($pagination['total_pages'] > 1): ?>
+        <nav>
+            <ul class="pagination">
+                <?php for ($i = 1; $i <= $pagination['total_pages']; $i++): ?>
+                    <li class="page-item<?= $i === $pagination['current_page'] ? ' active' : '' ?>">
+                        <a class="page-link" href="?<?= http_build_query(array_merge($filters, ['page' => $i])) ?>"><?= $i ?></a>
+                    </li>
+                <?php endfor; ?>
+            </ul>
+        </nav>
+    <?php endif; ?>
+</div>
+</body>
+</html>

--- a/views/tasks/view.php
+++ b/views/tasks/view.php
@@ -1,0 +1,86 @@
+<?php
+require_once __DIR__ . '/../../controllers/TaskController.php';
+require_once __DIR__ . '/../../controllers/CommentController.php';
+
+$id = (int)($_GET['id'] ?? 0);
+if (is_post()) {
+    if (isset($_POST['content'])) {
+        CommentController::store($id);
+    } elseif (isset($_FILES['attachment'])) {
+        TaskController::addAttachment($id);
+    }
+}
+
+$data = TaskController::view($id);
+$task = $data['task'];
+$comments = $data['comments'];
+$attachments = $data['attachments'];
+$activities = $data['activities'];
+$token = $_SESSION['csrf_token'] ?? '';
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>View Task</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container mt-5">
+    <h2 class="mb-4">Task Details</h2>
+    <?php if ($msg = flash('success')): ?>
+        <div class="alert alert-success"><?= $msg ?></div>
+    <?php elseif ($msg = flash('error')): ?>
+        <div class="alert alert-danger"><?= $msg ?></div>
+    <?php endif; ?>
+    <div class="mb-4">
+        <h4><?= htmlspecialchars($task['title'] ?? '') ?></h4>
+        <p><?= nl2br(htmlspecialchars($task['description'] ?? '')) ?></p>
+        <p><strong>Status:</strong> <?= htmlspecialchars($task['status'] ?? '') ?></p>
+        <p><strong>Priority:</strong> <?= htmlspecialchars($task['priority'] ?? '') ?></p>
+        <p><strong>Assignee:</strong> <?= htmlspecialchars($task['assignee_name'] ?? '') ?></p>
+    </div>
+    <div class="row">
+        <div class="col-md-6">
+            <h5>Comments</h5>
+            <ul class="list-group mb-3">
+                <?php foreach ($comments as $c): ?>
+                    <li class="list-group-item"><strong><?= htmlspecialchars($c['name']) ?>:</strong> <?= nl2br(htmlspecialchars($c['content'])) ?> <small class="text-muted float-end"><?= $c['created_at'] ?></small></li>
+                <?php endforeach; ?>
+            </ul>
+            <form method="post">
+                <input type="hidden" name="csrf_token" value="<?= $token ?>">
+                <div class="mb-3">
+                    <textarea name="content" class="form-control" rows="3" placeholder="Add comment"></textarea>
+                </div>
+                <button class="btn btn-primary" type="submit">Comment</button>
+            </form>
+        </div>
+        <div class="col-md-6">
+            <h5>Attachments</h5>
+            <ul class="list-group mb-3">
+                <?php foreach ($attachments as $a): ?>
+                    <li class="list-group-item"><a href="<?= $a['file_path'] ?>" target="_blank">Attachment <?= $a['id'] ?></a> <small class="text-muted">by <?= htmlspecialchars($a['name']) ?></small></li>
+                <?php endforeach; ?>
+            </ul>
+            <form method="post" enctype="multipart/form-data">
+                <input type="hidden" name="csrf_token" value="<?= $token ?>">
+                <div class="mb-3">
+                    <input type="file" name="attachment" class="form-control" required>
+                </div>
+                <button class="btn btn-secondary" type="submit">Upload</button>
+            </form>
+        </div>
+    </div>
+    <div class="mt-4">
+        <h5>Activity</h5>
+        <ul class="list-group">
+            <?php foreach ($activities as $act): ?>
+                <li class="list-group-item"><strong><?= htmlspecialchars($act['name']) ?></strong> <?= htmlspecialchars($act['action']) ?> <small class="text-muted float-end"><?= $act['created_at'] ?></small></li>
+            <?php endforeach; ?>
+        </ul>
+    </div>
+    <a href="index.php" class="btn btn-link mt-3">Back to list</a>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement task, comment, attachment, activity, and notification models
- add controllers for tasks with filters, comments, and notifications
- create Bootstrap task views with comments, attachments, and activity log

## Testing
- `php -l models/Task.php`
- `php -l models/Comment.php`
- `php -l models/Activity.php`
- `php -l models/Attachment.php`
- `php -l models/Notification.php`
- `php -l controllers/TaskController.php`
- `php -l controllers/CommentController.php`
- `php -l controllers/NotificationController.php`
- `php -l views/tasks/index.php`
- `php -l views/tasks/create.php`
- `php -l views/tasks/edit.php`
- `php -l views/tasks/view.php`


------
https://chatgpt.com/codex/tasks/task_e_68a116d6e8d4832d92df215b16f2d8c1