### PR TITLE
Add notification dropdown and model CRUD support

### DIFF
--- a/controllers/NotificationController.php
+++ b/controllers/NotificationController.php
@@ -27,18 +27,27 @@ class NotificationController
     }
 
     /**
+     * Fetch unread notifications for current user.
+     */
+    public static function unread(): array
+    {
+        require_login();
+        $user = current_user();
+        return Notification::unreadForUser($user['id']);
+    }
+
+    /**
      * Mark a notification as read.
      */
-    public static function mark(int $id): void
+    public static function mark(int $id): bool
     {
         require_login();
         $token = $_POST['csrf_token'] ?? '';
         if (!verify_csrf_token($token)) {
             http_response_code(400);
             flash('error', 'Invalid CSRF token.');
-            return;
+            return false;
         }
-        Notification::markAsRead($id);
-        redirect('views/notifications/index.php');
+        return Notification::markAsRead($id);
     }
 }

--- a/models/Notification.php
+++ b/models/Notification.php
@@ -36,12 +36,34 @@ class Notification
     }
 
     /**
+     * Retrieve unread notifications for a user.
+     */
+    public static function unreadForUser(int $userId): array
+    {
+        $pdo = Database::getConnection();
+        $sql = 'SELECT * FROM notifications WHERE user_id = :id AND is_read = 0 ORDER BY created_at DESC';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute(['id' => $userId]);
+        return $stmt->fetchAll();
+    }
+
+    /**
      * Mark a notification as read.
      */
     public static function markAsRead(int $id): bool
     {
         $pdo = Database::getConnection();
         $stmt = $pdo->prepare('UPDATE notifications SET is_read = 1 WHERE id = :id');
+        return $stmt->execute(['id' => $id]);
+    }
+
+    /**
+     * Delete a notification.
+     */
+    public static function delete(int $id): bool
+    {
+        $pdo = Database::getConnection();
+        $stmt = $pdo->prepare('DELETE FROM notifications WHERE id = :id');
         return $stmt->execute(['id' => $id]);
     }
 }

--- a/views/partials/topbar.php
+++ b/views/partials/topbar.php
@@ -1,0 +1,42 @@
+<?php
+require_once __DIR__ . '/../../controllers/NotificationController.php';
+require_once __DIR__ . '/../../utils/helpers.php';
+
+if (is_post() && isset($_POST['read_notification_id'])) {
+    NotificationController::mark((int)$_POST['read_notification_id']);
+}
+
+$notifications = NotificationController::unread();
+$token = generate_csrf_token();
+?>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/">Task Manager</a>
+        <div class="collapse navbar-collapse">
+            <ul class="navbar-nav ms-auto">
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" href="#" id="notificationsDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                        Notifications (<?= count($notifications) ?>)
+                    </a>
+                    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="notificationsDropdown">
+                        <?php if (empty($notifications)): ?>
+                            <li class="dropdown-item text-muted">No new notifications</li>
+                        <?php else: ?>
+                            <?php foreach ($notifications as $n): ?>
+                                <li>
+                                    <form method="post" class="dropdown-item d-flex justify-content-between align-items-start">
+                                        <span class="me-2"><?= htmlspecialchars($n['message']) ?></span>
+                                        <input type="hidden" name="csrf_token" value="<?= $token ?>">
+                                        <input type="hidden" name="read_notification_id" value="<?= $n['id'] ?>">
+                                        <button type="submit" class="btn btn-sm btn-link">Mark</button>
+                                    </form>
+                                </li>
+                            <?php endforeach; ?>
+                        <?php endif; ?>
+                    </ul>
+                </li>
+            </ul>
+        </div>
+    </div>
+</nav>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/views/tasks/create.php
+++ b/views/tasks/create.php
@@ -14,6 +14,7 @@ $token = generate_csrf_token();
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
+<?php include __DIR__ . '/../partials/topbar.php'; ?>
 <div class="container mt-5">
     <h2 class="mb-4">Create Task</h2>
     <?php if ($msg = flash('error')): ?>

--- a/views/tasks/edit.php
+++ b/views/tasks/edit.php
@@ -15,6 +15,7 @@ $token = generate_csrf_token();
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
+<?php include __DIR__ . '/../partials/topbar.php'; ?>
 <div class="container mt-5">
     <h2 class="mb-4">Edit Task</h2>
     <?php if ($msg = flash('error')): ?>

--- a/views/tasks/index.php
+++ b/views/tasks/index.php
@@ -21,6 +21,7 @@ $token = generate_csrf_token();
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
+<?php include __DIR__ . '/../partials/topbar.php'; ?>
 <div class="container mt-5">
     <h2 class="mb-4">Tasks</h2>
     <?php if ($msg = flash('success')): ?>

--- a/views/tasks/view.php
+++ b/views/tasks/view.php
@@ -26,6 +26,7 @@ $token = $_SESSION['csrf_token'] ?? '';
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
+<?php include __DIR__ . '/../partials/topbar.php'; ?>
 <div class="container mt-5">
     <h2 class="mb-4">Task Details</h2>
     <?php if ($msg = flash('success')): ?>

--- a/views/users/create.php
+++ b/views/users/create.php
@@ -12,6 +12,7 @@ $token = generate_csrf_token();
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
+<?php include __DIR__ . '/../partials/topbar.php'; ?>
 <div class="container mt-5" style="max-width: 500px;">
     <h2 class="mb-4">Create User</h2>
     <?php if ($msg = flash('error')): ?>

--- a/views/users/edit.php
+++ b/views/users/edit.php
@@ -16,6 +16,7 @@ if (!$user) {
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
+<?php include __DIR__ . '/../partials/topbar.php'; ?>
 <div class="container mt-5" style="max-width: 500px;">
     <h2 class="mb-4">Edit User</h2>
     <?php if ($msg = flash('error')): ?>

--- a/views/users/index.php
+++ b/views/users/index.php
@@ -16,6 +16,7 @@ $token = generate_csrf_token();
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
+<?php include __DIR__ . '/../partials/topbar.php'; ?>
 <div class="container mt-5">
     <h2 class="mb-4">Users</h2>
     <?php if ($msg = flash('success')): ?>


### PR DESCRIPTION
## Summary
- extend Notification model with unread fetch and delete helpers
- add NotificationController methods to retrieve unread items and mark them read
- show a Bootstrap notification dropdown in a shared top bar

## Testing
- `php -l controllers/NotificationController.php models/Notification.php views/partials/topbar.php views/tasks/index.php views/tasks/create.php views/tasks/edit.php views/tasks/view.php views/users/index.php views/users/create.php views/users/edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68a11f9f82f8832dae916640a7fcef2f